### PR TITLE
feat: Update Dioxus to v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "dioxus_markdown"
-version = "0.1.0"
-edition = "2018"
+version = "0.2.0"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus = "0.3"
-pulldown-cmark = "0.9.1"
+dioxus = "0.4"
+pulldown-cmark = "0.9.3"
 
 [dev-dependencies]
-dioxus-desktop = "0.3"
+dioxus-desktop = "0.4"


### PR DESCRIPTION
This PR updates the Dioxus dependency to 0.4. It also includes updates to the Rust edition and `pulldown-cmark` crate. Version 0.9.3 includes some changes that [may alter output](https://github.com/raphlinus/pulldown-cmark/releases/tag/v0.9.3), so I've incremented the minor version to 2.

I was unable to verify the example on my machine due to multiple dependency issues.

If any of these changes besides the Dioxus upgrade are unwelcome, I can remove them.