### PR TITLE
Enable generic backend with Dioxus `html` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-dioxus = { git = "https://github.com/dioxuslabs/dioxus", features = ["html"] }
+dioxus = { version = "0.5.1", features = ["html"] }
 pulldown-cmark = "0.9.3"
 
 [dev-dependencies]
-dioxus = { git = "https://github.com/dioxuslabs/dioxus", features = ["desktop"] }
+dioxus = { version = "0.5.1", features = ["desktop"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,8 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-dioxus = { git = "https://github.com/dioxuslabs/dioxus", features = ["web"] }
+dioxus = { git = "https://github.com/dioxuslabs/dioxus", features = ["html"] }
 pulldown-cmark = "0.9.3"
+
+[dev-dependencies]
+dioxus = { git = "https://github.com/dioxuslabs/dioxus", features = ["desktop"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,6 @@ name = "dioxus_markdown"
 version = "0.2.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-dioxus = { version = "0.5", features = ["desktop"] }
+dioxus = { git = "https://github.com/dioxuslabs/dioxus", features = ["web"] }
 pulldown-cmark = "0.9.3"
-
-[dev-dependencies]
-dioxus = { version = "0.5", features = ["desktop"] }


### PR DESCRIPTION
Using the `html` feature flag here seems to let me use this crate from both `web` and `desktop` platforms